### PR TITLE
Remove docs section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ pnpm install
 tauri dev
 ```
 
-## Documentation
-
-For detailed documentation and guides, visit our [Documentation Site](https://docs.krome.dev)
-
 ## Community
 
 Join our community to get help, share your projects, and contribute:


### PR DESCRIPTION
- The docs site does not exist yet, so no point in linking to it from the README just yet